### PR TITLE
Correct note information in noteFullyCut events

### DIFF
--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -32,6 +32,7 @@ namespace BeatSaberHTTPStatus {
 		private BeatmapObjectCallbackController beatmapObjectCallbackController;
 		private PlayerHeadAndObstacleInteraction playerHeadAndObstacleInteraction;
 		private GameEnergyCounter gameEnergyCounter;
+		private Dictionary<NoteCutInfo, NoteData> noteCutMapping = new Dictionary<NoteCutInfo, NoteData>();
 
 		/// protected NoteCutInfo AfterCutScoreBuffer._noteCutInfo
 		private FieldInfo noteCutInfoField = typeof(AfterCutScoreBuffer).GetField("_noteCutInfo", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
@@ -343,6 +344,8 @@ namespace BeatSaberHTTPStatus {
 			foreach (AfterCutScoreBuffer acsb in list) {
 				if (noteCutInfoField.GetValue(acsb) == noteCutInfo) {
 					// public AfterCutScoreBuffer#didFinishEvent<AfterCutScoreBuffer>
+					noteCutMapping.Add(noteCutInfo, noteData);
+
 					acsb.didFinishEvent += OnNoteWasFullyCut;
 					break;
 				}
@@ -354,8 +357,15 @@ namespace BeatSaberHTTPStatus {
 			int afterScore;
 			int cutDistanceScore;
 
+			NoteCutInfo noteCutInfo = (NoteCutInfo) noteCutInfoField.GetValue(acsb);
+			NoteData noteData = noteCutMapping[noteCutInfo];
+
+			noteCutMapping.Remove(noteCutInfo);
+
+			SetNoteCutStatus(noteData, noteCutInfo);
+
 			// public ScoreController.ScoreWithoutMultiplier(NoteCutInfo, SaberAfterCutSwingRatingCounter, out int beforeCutScore, out int afterCutScore, out int cutDistanceScore)
-			ScoreController.ScoreWithoutMultiplier((NoteCutInfo) noteCutInfoField.GetValue(acsb), null, out score, out afterScore, out cutDistanceScore);
+			ScoreController.ScoreWithoutMultiplier(noteCutInfo, null, out score, out afterScore, out cutDistanceScore);
 
 			int multiplier = (int) afterCutScoreBufferMultiplierField.GetValue(acsb);
 


### PR DESCRIPTION
Currently, noteFullyCut events do not always contain the correct note information. This is caused by note information being stored in a shared object (statusManager.gameStatus). When hitting multiple notes simultaneously, the noteCut events contain the correct information, but the following noteFullyCut events contain the note info of the last note cut, and only the initialScore, finalScore and cutMultiplier are correct, as they are set separately.

This PR corrects this behaviour by calling SetNoteCutStatus in OnNoteWasFullyCut. Since this requires the NoteData object, which is not normally available within OnNoteWasFullyCut, this also adds a mapping table to get the NoteData given a NoteCutInfo object.