### PR TITLE
Bugfix/Fix songHash exposure (#39)

### DIFF
--- a/BeatSaberHTTPStatus/GameStatus.cs
+++ b/BeatSaberHTTPStatus/GameStatus.cs
@@ -16,6 +16,7 @@ namespace BeatSaberHTTPStatus {
 		public string levelAuthorName = null;
 		public string songCover = null;
 		public string songHash = null;
+		public string levelId = null;
 		public float songBPM;
 		public float noteJumpSpeed;
 		public long songTimeOffset = 0;
@@ -115,6 +116,7 @@ namespace BeatSaberHTTPStatus {
 			this.levelAuthorName = null;
 			this.songCover = null;
 			this.songHash = null;
+			this.levelId = null;
 			this.songBPM = 0f;
 			this.noteJumpSpeed = 0f;
 			this.songTimeOffset = 0;

--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -203,6 +203,7 @@ namespace BeatSaberHTTPStatus {
 				gameStatus.songBPM = level.beatsPerMinute;
 				gameStatus.noteJumpSpeed = diff.noteJumpMovementSpeed;
 				gameStatus.songHash = level.levelID.Replace("custom_level_", "").Replace(" WIP", "");
+				gameStatus.levelId = level.levelID;
 				gameStatus.songTimeOffset = (long) (level.songTimeOffset * 1000f / songSpeedMul);
 				gameStatus.length = (long) (level.beatmapLevelData.audioClip.length * 1000f / songSpeedMul);
 				gameStatus.start = GetCurrentTime() - (long) (audioTimeSyncController.songTime * 1000f / songSpeedMul);

--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -203,7 +203,7 @@ namespace BeatSaberHTTPStatus {
 				gameStatus.songBPM = level.beatsPerMinute;
 				gameStatus.noteJumpSpeed = diff.noteJumpMovementSpeed;
 				// 13 is a magical number for the length of "custom_level_"
-				gameStatus.songHash = level.levelID.StartsWith("custom_level_") && !level.levelID.EndsWith(" WIP") ? level.levelID.Substring(13, level.levelID.Length - 13) : null;
+				gameStatus.songHash = level.levelID.StartsWith("custom_level_") && !level.levelID.EndsWith(" WIP") ? level.levelID.Substring(13) : null;
 				gameStatus.levelId = level.levelID;
 				gameStatus.songTimeOffset = (long) (level.songTimeOffset * 1000f / songSpeedMul);
 				gameStatus.length = (long) (level.beatmapLevelData.audioClip.length * 1000f / songSpeedMul);

--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -202,7 +202,7 @@ namespace BeatSaberHTTPStatus {
 				gameStatus.levelAuthorName = level.levelAuthorName;
 				gameStatus.songBPM = level.beatsPerMinute;
 				gameStatus.noteJumpSpeed = diff.noteJumpMovementSpeed;
-				gameStatus.songHash = level.levelID.Substring(0, Math.Min(32, level.levelID.Length));
+				gameStatus.songHash = level.levelID.Replace("custom_level_", "").Replace(" WIP", "");
 				gameStatus.songTimeOffset = (long) (level.songTimeOffset * 1000f / songSpeedMul);
 				gameStatus.length = (long) (level.beatmapLevelData.audioClip.length * 1000f / songSpeedMul);
 				gameStatus.start = GetCurrentTime() - (long) (audioTimeSyncController.songTime * 1000f / songSpeedMul);

--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -202,7 +202,8 @@ namespace BeatSaberHTTPStatus {
 				gameStatus.levelAuthorName = level.levelAuthorName;
 				gameStatus.songBPM = level.beatsPerMinute;
 				gameStatus.noteJumpSpeed = diff.noteJumpMovementSpeed;
-				gameStatus.songHash = level.levelID.Replace("custom_level_", "").Replace(" WIP", "");
+				// 13 is a magical number for the length of "custom_level_"
+				gameStatus.songHash = level.levelID.StartsWith("custom_level_") && !level.levelID.EndsWith(" WIP") ? level.levelID.Substring(13, level.levelID.Length - 13) : null;
 				gameStatus.levelId = level.levelID;
 				gameStatus.songTimeOffset = (long) (level.songTimeOffset * 1000f / songSpeedMul);
 				gameStatus.length = (long) (level.beatmapLevelData.audioClip.length * 1000f / songSpeedMul);

--- a/BeatSaberHTTPStatus/StatusManager.cs
+++ b/BeatSaberHTTPStatus/StatusManager.cs
@@ -81,6 +81,7 @@ namespace BeatSaberHTTPStatus {
 			beatmapJSON["songAuthorName"] = stringOrNull(gameStatus.songAuthorName);
 			beatmapJSON["levelAuthorName"] = stringOrNull(gameStatus.levelAuthorName);
 			beatmapJSON["songCover"] = String.IsNullOrEmpty(gameStatus.songCover) ? (JSONNode) JSONNull.CreateOrGet() : (JSONNode) new JSONString(gameStatus.songCover);
+			beatmapJSON["songHash"] = stringOrNull(gameStatus.songHash);
 			beatmapJSON["songBPM"] = gameStatus.songBPM;
 			beatmapJSON["noteJumpSpeed"] = gameStatus.noteJumpSpeed;
 			beatmapJSON["songTimeOffset"] = new JSONNumber(gameStatus.songTimeOffset);

--- a/BeatSaberHTTPStatus/StatusManager.cs
+++ b/BeatSaberHTTPStatus/StatusManager.cs
@@ -82,6 +82,7 @@ namespace BeatSaberHTTPStatus {
 			beatmapJSON["levelAuthorName"] = stringOrNull(gameStatus.levelAuthorName);
 			beatmapJSON["songCover"] = String.IsNullOrEmpty(gameStatus.songCover) ? (JSONNode) JSONNull.CreateOrGet() : (JSONNode) new JSONString(gameStatus.songCover);
 			beatmapJSON["songHash"] = stringOrNull(gameStatus.songHash);
+			beatmapJSON["levelId"] = stringOrNull(gameStatus.levelId);
 			beatmapJSON["songBPM"] = gameStatus.songBPM;
 			beatmapJSON["noteJumpSpeed"] = gameStatus.noteJumpSpeed;
 			beatmapJSON["songTimeOffset"] = new JSONNumber(gameStatus.songTimeOffset);

--- a/protocol.md
+++ b/protocol.md
@@ -44,6 +44,7 @@ StatusObject = {
 		"levelAuthorName": String, // Beatmap author name
 		"songCover": null | String, // Base64 encoded PNG image of the song cover
 		"songHash": String, // Unique beatmap identifier. At most 32 characters long. Same for all difficulties.
+		"levelId": String, // Raw levelId for a song. Same for all difficulties. 
 		"songBPM": Number, // Song Beats Per Minute
 		"noteJumpSpeed": Number, // Song note jump movement speed, how fast the notes move towards the player.
 		"songTimeOffset": Integer, // Time in millis of where in the song the beatmap starts. Adjusted for song speed multiplier.

--- a/protocol.md
+++ b/protocol.md
@@ -43,7 +43,7 @@ StatusObject = {
 		"songAuthorName": String, // Song author name
 		"levelAuthorName": String, // Beatmap author name
 		"songCover": null | String, // Base64 encoded PNG image of the song cover
-		"songHash": String, // Unique beatmap identifier. At most 32 characters long. Same for all difficulties.
+		"songHash": String, // Unique beatmap identifier. Same for all difficulties. Is extracted from the levelId and will return null for OST and WIP songs.
 		"levelId": String, // Raw levelId for a song. Same for all difficulties. 
 		"songBPM": Number, // Song Beats Per Minute
 		"noteJumpSpeed": Number, // Song note jump movement speed, how fast the notes move towards the player.


### PR DESCRIPTION
This PR should resolve #32 (kinda) and also resolves #39 

It exposes the songHash and fixes the extraction of the songHash as the format has changed.

## Benchmarks of extraction code
The way of extraction has also been benchmarked and optimized for the most common use case (being custom songs) using the following piece of code
```csharp
using System;
using System.Text.RegularExpressions;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Environments;
using BenchmarkDotNet.Exporters;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;

namespace Benchmarks
{
	class Program
	{
		static void Main(string[] args)
		{
			BenchmarkRunner.Run<SongHashBenchmark>(DefaultConfig.Instance
				.AddJob(Job.Default.WithRuntime(ClrRuntime.Net461)
					.WithJit(Jit.Default))
				.AddDiagnoser(MemoryDiagnoser.Default)
				.AddExporter(BenchmarkReportExporter.Default, HtmlExporter.Default, MarkdownExporter.GitHub)
				.KeepBenchmarkFiles());
		}
	}
	
	public class SongHashBenchmark
	{
		[Params(
			"AngelVoices",
			"custom_level_DD12E126F4AB384AF7D20154416DCCEEB173380E",
			"custom_level_DD12E126F4AB384AF7D20154416DCCEEB173380E WIP")]
		public string LevelId;
		
		public readonly Regex CompiledSongHashRegex = new Regex("^custom_level_(.*)(?<! WIP)$", RegexOptions.Compiled);

		[Benchmark(Baseline = true)]
		public string ExtractUsingSubstring()
		{
			if (LevelId.StartsWith("custom_level_") && !LevelId.EndsWith(" WIP"))
			{
				return LevelId.Substring(13, LevelId.Length - 13);
			}
			else
			{
				return null;
			}
		}

		[Benchmark]
		public string ExtractUsingOnlyReplace()
		{
			if (LevelId.StartsWith("custom_level_") && !LevelId.EndsWith(" WIP"))
			{
				return LevelId.Replace("custom_level_", string.Empty);
			}
			else
			{
				return null;
			}
		}

		[Benchmark]
		public string ExtractUsingOnlySplit()
		{
			if (LevelId.StartsWith("custom_level_") && !LevelId.EndsWith(" WIP"))
			{
				return LevelId.Split(new[] {"custom_level_"}, StringSplitOptions.RemoveEmptyEntries)[0];
			}
			else
			{
				return null;
			}
		}

		[Benchmark]
		public string ExtractUsingRegex()
		{
			var match = CompiledSongHashRegex.Match(LevelId);
			return match.Success ? match.Groups[1].Value : null;
		}
	}
}
```

## With the following results

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.815 (1909/November2018Update/19H2)
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=3.1.201
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  Job-NRJDXI : .NET Framework 4.8 (4.8.4150.0), X64 RyuJIT

Jit=Default  Runtime=.NET 4.6.1  

|                  Method |              LevelId |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |--------------------- |------------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|   ExtractUsingSubstring |          AngelVoices |    76.83 ns |  1.549 ns |  1.449 ns |  1.00 |    0.00 |      - |     - |     - |         - |
| ExtractUsingOnlyReplace |          AngelVoices |    76.97 ns |  1.167 ns |  1.092 ns |  1.00 |    0.03 |      - |     - |     - |         - |
|   ExtractUsingOnlySplit |          AngelVoices |    76.76 ns |  1.560 ns |  1.670 ns |  1.00 |    0.03 |      - |     - |     - |         - |
|       ExtractUsingRegex |          AngelVoices |    64.36 ns |  0.933 ns |  0.873 ns |  0.84 |    0.02 |      - |     - |     - |         - |
|                         |                      |             |           |           |       |         |        |       |       |           |
|   ExtractUsingSubstring | custo(...)3380E [53] |   191.98 ns |  3.082 ns |  2.883 ns |  1.00 |    0.00 | 0.0675 |     - |     - |     112 B |
| ExtractUsingOnlyReplace | custo(...)3380E [53] |   315.82 ns |  4.415 ns |  4.130 ns |  1.65 |    0.03 | 0.0672 |     - |     - |     112 B |
|   ExtractUsingOnlySplit | custo(...)3380E [53] |   348.05 ns |  2.281 ns |  1.905 ns |  1.82 |    0.03 | 0.4201 |     - |     - |     698 B |
|       ExtractUsingRegex | custo(...)3380E [53] |   294.72 ns |  5.490 ns |  5.135 ns |  1.54 |    0.04 | 0.3185 |     - |     - |     530 B |
|                         |                      |             |           |           |       |         |        |       |       |           |
|   ExtractUsingSubstring | custo(...)E WIP [57] |   178.54 ns |  3.234 ns |  3.026 ns |  1.00 |    0.00 |      - |     - |     - |         - |
| ExtractUsingOnlyReplace | custo(...)E WIP [57] |   177.78 ns |  2.878 ns |  2.692 ns |  1.00 |    0.01 |      - |     - |     - |         - |
|   ExtractUsingOnlySplit | custo(...)E WIP [57] |   178.85 ns |  2.917 ns |  2.728 ns |  1.00 |    0.01 |      - |     - |     - |         - |
|       ExtractUsingRegex | custo(...)E WIP [57] | 1,366.01 ns | 18.618 ns | 17.415 ns |  7.65 |    0.11 |      - |     - |     - |         - |


