### PR TITLE
#3 Fix for lags occuring when using websockets

### DIFF
--- a/BeatSaberHTTPStatus/HTTPServer.cs
+++ b/BeatSaberHTTPStatus/HTTPServer.cs
@@ -73,7 +73,7 @@ namespace BeatSaberHTTPStatus {
 			eventJSON["time"] = new JSONNumber(Plugin.GetCurrentTime());
 			eventJSON["status"] = statusManager.statusJSON;
 
-			Send(eventJSON.ToString());
+			SendAsync(eventJSON.ToString(), b => {});
 		}
 
 		protected override void OnClose(CloseEventArgs e) {
@@ -108,7 +108,7 @@ namespace BeatSaberHTTPStatus {
 				eventJSON["beatmapEvent"] = statusManager.beatmapEventJSON;
 			}
 
-			Send(eventJSON.ToString());
+			SendAsync(eventJSON.ToString(), b => {});
 		}
 	}
 }


### PR DESCRIPTION
This resolves the lag spikes when a websocket client is connected, which are noted in #3.

Goals of this PR:
- [X] Asynchronous WebSocket
- [X] Web Request `/status.json` *was already* asynchronous ([click here to see why](https://github.com/sta/websocket-sharp/blob/cb824723f07f77762dbfb873226388e3922b9945/websocket-sharp/Server/HttpServer.cs#L944))






### Important
Please note that I throw away the result of the SendAsync call. This means we do not wait for the packet to arrive. This causes two things:
* First, we do not have to wait before we can send the next packet, meaning we won't have a lot of packages piling up.
* Second, the packets *may* arrive out of order at the client side. But as the packets contain the NoteId the client simply can solve that by himself.