### PR TITLE
Added an energy value to Performance.

### DIFF
--- a/BeatSaberHTTPStatus/GameStatus.cs
+++ b/BeatSaberHTTPStatus/GameStatus.cs
@@ -46,6 +46,7 @@ namespace BeatSaberHTTPStatus {
 		public int multiplier = 0;
 		public float multiplierProgress = 0;
 		public int batteryEnergy = 1;
+		public float energy = 0;
 
 		// Note cut
 		public int noteID = -1;
@@ -146,6 +147,7 @@ namespace BeatSaberHTTPStatus {
 			this.multiplier = 0;
 			this.multiplierProgress = 0;
 			this.batteryEnergy = 1;
+			this.energy = 0;
 		}
 
 		public void ResetNoteCut() {

--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -107,6 +107,10 @@ namespace BeatSaberHTTPStatus {
 				scoreController.multiplierDidChangeEvent -= OnMultiplierDidChange;
 			}
 
+			if (gameEnergyCounter != null) {
+				gameEnergyCounter.gameEnergyDidChangeEvent -= OnEnergyDidChange;
+			}
+
 			CleanUpMultiplayer();
 
 			if (beatmapObjectCallbackController != null) {
@@ -237,6 +241,8 @@ namespace BeatSaberHTTPStatus {
 			scoreController.comboDidChangeEvent += OnComboDidChange;
 			// public ScoreController#multiplierDidChangeEvent<int, float> // multiplier, progress [0..1]
 			scoreController.multiplierDidChangeEvent += OnMultiplierDidChange;
+			// public GameEnergyCounter#gameEnergyDidChangeEvent<float> // energy
+			gameEnergyCounter.gameEnergyDidChangeEvent += OnEnergyDidChange;
 			log.Info("2.5");
 			// public event Action<BeatmapEventData> BeatmapObjectCallbackController#beatmapEventDidTriggerEvent
 			beatmapObjectCallbackController.beatmapEventDidTriggerEvent += OnBeatmapEventDidTrigger;
@@ -595,6 +601,11 @@ namespace BeatSaberHTTPStatus {
 			statusManager.gameStatus.combo = combo;
 			// public int ScoreController#maxCombo
 			statusManager.gameStatus.maxCombo = scoreController.maxCombo;
+		}
+
+		public void OnEnergyDidChange(float energy) {
+			statusManager.gameStatus.energy = energy;
+			statusManager.EmitStatusUpdate(ChangedProperties.Performance, "energyChanged");
 		}
 
 		public void OnMultiplierDidChange(int multiplier, float multiplierProgress) {

--- a/BeatSaberHTTPStatus/StatusManager.cs
+++ b/BeatSaberHTTPStatus/StatusManager.cs
@@ -121,6 +121,7 @@ namespace BeatSaberHTTPStatus {
 			performanceJSON["multiplier"] = gameStatus.multiplier;
 			performanceJSON["multiplierProgress"] = gameStatus.multiplierProgress;
 			performanceJSON["batteryEnergy"] = gameStatus.modBatteryEnergy || gameStatus.modInstaFail ? (JSONNode) new JSONNumber(gameStatus.batteryEnergy) : (JSONNode) JSONNull.CreateOrGet();
+			performanceJSON["energy"] = gameStatus.energy;
 		}
 
 		private void UpdateNoteCutJSON() {

--- a/protocol.md
+++ b/protocol.md
@@ -73,6 +73,7 @@ StatusObject = {
 		"multiplier": Integer, // Current combo multiplier {1, 2, 4, 8}
 		"multiplierProgress": Number, // Current combo multiplier progress [0..1)
 		"batteryEnergy": null | Integer, // Current amount of battery lives left. null if Battery Energy and Insta Fail are disabled.
+		"energy": Number, // Current energy
 	},
 	"mod": {
 		"multiplier": Number, // Current score multiplier for gameplay modifiers
@@ -256,6 +257,12 @@ Contains only the `performance` property of [Status object](#status-object).
 ### `scoreChanged` event
 
 Fired when the score changes.
+
+Contains only the `performance` property of [Status object](#status-object).
+
+### `energyChanged` event
+
+Fired when the energy changes.
 
 Contains only the `performance` property of [Status object](#status-object).
 


### PR DESCRIPTION
When 'Modifiers' is 'Insta Fail' or 'Battery Energy' you can get 'batteryEnergy', but in normal mode you can't get 'energy', so I added it.

I was wondering if I should add an 'energyChanged' event.

The 'noteCut', 'noteMissed' and 'bombCut' events don't update 'energy' and they update immediately after, so 'energy' is not updated until the next event.

Also, when the 'obstacleEnter' event occurs, you won't get an event that incrementally decreases 'energy'.

Therefore, we thought the 'energyChanged' event was necessary.

In BS Utils 1.6.1, line 259 of the modified source code, 'gameStatus.mode = Gamemode.GameMode;' had to be commented out to be able to build, so I checked that.

I'm using a translation tool, so please be aware that there may be some strange sentences.