### PR TITLE
Write to websocket asynchronously, plus fix thread-safety issues

### DIFF
--- a/BeatSaberHTTPStatus/StatusManager.cs
+++ b/BeatSaberHTTPStatus/StatusManager.cs
@@ -44,7 +44,7 @@ namespace BeatSaberHTTPStatus {
 			}
 			if (changedProps.beatmapEvent) UpdateBeatmapEventJSON();
 
-			if (statusChange != null) statusChange(this, changedProps, cause);
+			statusChange?.Invoke(this, changedProps, cause);
 		}
 
 		private void UpdateAll() {


### PR DESCRIPTION
This fixes #3 and obsoletes #54. Additionally some thread-safety issues have been fixed so that all game-reading code happens from within the game thread. These two things have been done in separate commits. (I would have made them separate PRs except that my commit for the threading fixes depended on my async-send change.)

In https://github.com/opl-/beatsaber-http-status/issues/3#issuecomment-817007287, I theorized that the Send call inside of HTTPServer.StatusBroadcastBehavior.OnStatusChange was the cause of stuttering while using the mod. I tested this by adding some timing around the send call:

```csharp
			var s = eventJSON.ToString();

			var watch = new System.Diagnostics.Stopwatch();
			watch.Start();
			QueuedSend(s);
			watch.Stop();

			Console.WriteLine($"Execution Time: {watch.ElapsedMilliseconds} ms");
```

I got results like this:

<details><summary>Original Results</summary>

```
[INFO @ 07:42:20 | _] Execution Time: 48 ms
[INFO @ 07:42:26 | _] Execution Time: 0 ms
[INFO @ 07:42:26 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 49 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:27 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 0 ms
[INFO @ 07:42:28 | _] Execution Time: 46 ms
```
</details>

This is all within the main game thread, so the synchronous IO is regularly causing stuttering. (At 90fps, each frame has 11ms to happen, so blocking the main thread for an extra 40+ms regularly is pretty bad.) (I also did some timing around other parts of OnStatusChange and the rest of it was just zeroes.)

After the first commit, the results look perfect like this:

<details><summary>Fixed Results</summary>

```
[INFO @ 08:26:22 | _] Send execution Time: 0 ms
[INFO @ 08:26:22 | _] Send execution Time: 0 ms
[INFO @ 08:26:30 | _] Send execution Time: 0 ms
[INFO @ 08:26:30 | _] Send execution Time: 0 ms
[INFO @ 08:26:30 | _] Send execution Time: 0 ms
[INFO @ 08:26:30 | _] Send execution Time: 0 ms
[INFO @ 08:26:30 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:31 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:32 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:33 | _] Send execution Time: 0 ms
[INFO @ 08:26:34 | _] Send execution Time: 0 ms
[INFO @ 08:26:34 | _] Send execution Time: 0 ms
[INFO @ 08:26:34 | _] Send execution Time: 0 ms
[INFO @ 08:26:34 | _] Send execution Time: 0 ms
[INFO @ 08:26:34 | _] Send execution Time: 0 ms
[INFO @ 08:26:34 | _] Send execution Time: 0 ms
[INFO @ 08:26:35 | _] Send execution Time: 0 ms
[INFO @ 08:26:35 | _] Send execution Time: 0 ms
[INFO @ 08:26:35 | _] Send execution Time: 0 ms
[INFO @ 08:26:35 | _] Send execution Time: 0 ms
[INFO @ 08:26:38 | _] Send execution Time: 0 ms
```
</details>

The asynchronous send fix properly queues up writes to the websocket.

Next, I noticed that HTTPServer would directly read from the StatusManager in response to web requests and websocket events even though StatusManager was written to from the main game thread. I made the code thread-safe by making sure that all access to StatusManager happened through the game thread.

(I did consider an alternate solution: It would be possible to make it so that StatusManager.EmitStatusUpdate wrote all of its results to a single volatile property, and then HTTPServer could read this volatile property when handling requests and websocket events, but this would have been a bigger change for negligible benefit that would make the code harder to evolve. In comparison, the change to just read from StatusManager within the game thread is a very small drop-in fix.)