### PR TITLE
Fixed an exception when SongCore is not installed.

### DIFF
--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -343,7 +344,7 @@ namespace BeatSaberHTTPStatus {
 			gameStatus.songBPM = level.beatsPerMinute;
 			gameStatus.noteJumpSpeed = diff.noteJumpMovementSpeed;
 			// 13 is "custom_level_" and 40 is the magic number for the length of the SHA-1 hash
-			gameStatus.songHash = level.levelID.StartsWith("custom_level_") && !level.levelID.EndsWith(" WIP") ? level.levelID.Substring(13, 40) : null;
+			gameStatus.songHash = Regex.IsMatch(level.levelID, "^custom_level_[0-9A-F]{40}", RegexOptions.IgnoreCase) && !level.levelID.EndsWith(" WIP") ? level.levelID.Substring(13, 40) : null;
 			gameStatus.levelId = level.levelID;
 			gameStatus.songTimeOffset = (long) (level.songTimeOffset * 1000f / songSpeedMul);
 			gameStatus.length = (long) (level.beatmapLevelData.audioClip.length * 1000f / songSpeedMul);


### PR DESCRIPTION
The fix for the following pull request was found to cause an `ArgumentOutOfRangeException` exception when SongCore is not installed.
https://github.com/opl-/beatsaber-http-status/pull/44

If SongCore is not installed, `songHash` in `levelID` will be the folder name of the map.

| SongCore | levelID |
-----------|----------
| installed | custom_level_8A40E06E3A4EB6DC56428B0A59B89219029C433D |
| not installed | custom_level_15cb3 (I'LL SHOW YOU - Emilia) |

However, since there are few environments that do not have SongCore installed, I think the problem will occur in few cases.