### PR TITLE
Fix missing score data in solo play after playing a map in multiplayer, Fix errors when starting the tutorial

### DIFF
--- a/BeatSaberHTTPStatus/Plugin.cs
+++ b/BeatSaberHTTPStatus/Plugin.cs
@@ -229,7 +229,7 @@ namespace BeatSaberHTTPStatus {
 			if (!BS_Utils.Plugin.LevelData.IsSet) {
 				Plugin.log.Debug("BS_Utils level data is not present. Probably due to the tutorial being active.");
 				return;
-            }
+			}
 
 			GameStatus gameStatus = statusManager.gameStatus;
 


### PR DESCRIPTION
When playing a map in multiplayer mode, a couple of game objects (for example the ScoreController) linger around until the next game restart. When going back to solo play after playing a map in multiplayer, HTTP Status currently grabs the multiplayer objects and as a result is not getting certain data for the solo map.

Steps to reproduce with the layout by Reselim:
- Play a map in multiplayer, overlay is as expected
- Switch to solo play and start a map. The score on the overlay stays at 0.

This PR should fix at least part of it. There might be more cases of getting the wrong object, as I only tested with the data that was available on the old Reselim overlay.

This PR also adds an additional check if the level data is present in BS_Utils on HandleSongStart. HTTP Status currently throws multiple different errors when starting the tutorial (also different depending if the player played a map in multplayer before starting the tutorial) and this fixes it by doing nothing when entering the tutorial.